### PR TITLE
Update the d_text to use array in query string

### DIFF
--- a/example/testform.php
+++ b/example/testform.php
@@ -62,7 +62,9 @@ $formlink = "<form action = '$RESPONSE' method='POST'>\n";
 <input type="hidden" name="fldExperience_response" value="ran_outside">
 <input type="hidden" name="fldExperience_stand" value="1">
 <input type="hidden" name="fldEffects_shelved" value="1 few_toppled_or_fell">
-<input type="hidden" name="d_text" value="_tiltedwall">
+<input type="hidden" name="d_text[]" value="_tilesfell">
+<input type="hidden" name="d_text[]" value="_tiltedwall">
+<input type="hidden" name="d_text[]" value="_majoroldchim">
 <input type="hidden" name="fldEffects_furniture" value="1">
 <input type="hidden" name="fldContact_comments" value="a test comment">
 <input type="submit" name="ciim_report" value="Submit Form">

--- a/src/htdocs/inc/response.inc.php
+++ b/src/htdocs/inc/response.inc.php
@@ -83,37 +83,38 @@
     return $felt;
   }
 
+
   function dtext2damage() {
-    $D_LABEL = array (
-      0.5  => array( '_crackmin', '_crackwindows' ),
-      0.75 => array( '_crackwallfew' ),
-      1    => array( '_crackwallmany', '_crackwall','_crackfloor',
-                     '_crackchim', '_tilesfell' ),
-      2    => array( '_wall', '_pipe', '_win', '_brokenwindows',
-                     '_majoroldchim', '_masonryfell' ),
-      3    => array( '_move', '_chim', '_found', '_collapse',
-                     '_porch', '_majormodernchim', '_tiltedwall' ),
+    $D_LABEL = (object) array (
+      "3"    => array('_move', '_chim', '_found', '_collapse',
+                      '_porch', '_majormodernchim', '_tiltedwall'),
+      '2'    => array('_wall', '_pipe', '_win', '_brokenwindows',
+                      '_majoroldchim', '_masonryfell'),
+      '1'    => array('_crackwallmany', '_crackwall','_crackfloor',
+                      '_crackchim', '_tilesfell'),
+      '0.75' => array('_crackwallfew'),
+      '0.5'  => array('_crackmin', '_crackwindows')
     );
 
     if (array_key_exists('d_text[]',$_POST)) {
       // d_text is an array
       $text = $_POST['d_text[]'];
-    }
-    elseif (array_key_exists('d_text',$_POST)) {
+    } elseif (array_key_exists('d_text',$_POST)) {
       // d_text might be array or string
       $text = $_POST['d_text'];
       if (!is_array($text)) {
         $text = explode(' ',$text);
       }
-    }
-    else {
+    } else {
       return 0;
     }
     if (in_array('none',$text)) return 0;
 
-    foreach(array_reverse($D_LABEL) as $dam => $vals) {
+    foreach($D_LABEL as $dam => $vals) {
       foreach($vals as $val) {
-        if (in_array($val,$text)) return $dam;
+        if (in_array($val,$text)) {
+          return $dam;
+        }
       }
     }
     

--- a/src/htdocs/response.php
+++ b/src/htdocs/response.php
@@ -43,19 +43,8 @@ if (!isset($_POST['fldSituation_felt'])) {
 }
 
 // Fix PHP not parsing multiple checkboxes
-
-$d_text = array();
-foreach (explode('&',$rawData) as $string) {
-        list($key,$val)=explode('=',$string);
-        if ($key != 'd_text') {
-                continue;
-        }
-        $d_text[] = $val;
-}
-if ($d_text) {
-  $_POST['d_text[]'] = implode('&d_text[]=', $d_text);
-  unset($_POST['d_text']); // dont repeat the $_POST variable
-}
+$_POST['d_text[]'] = $_POST['d_text'];
+unset($_POST['d_text']); // dont repeat the $_POST variable
 
 // Main loop
 
@@ -92,7 +81,7 @@ $post = array();
 if (is_array($_POST)) {
 	foreach ($_POST as $k=>$v) {
 		if (is_array($v)) {
-			$post[] = "$k=" . implode(' ',$v);
+			$post[] = "$k=" . implode('&' . $k .'=',$v);
 		} else {
 			$post[] = "$k=$v";
 		}

--- a/src/htdocs/response.php
+++ b/src/htdocs/response.php
@@ -53,7 +53,8 @@ foreach (explode('&',$rawData) as $string) {
         $d_text[] = $val;
 }
 if ($d_text) {
-  $_POST['d_text'] = implode(' ',$d_text);
+  $_POST['d_text[]'] = implode('&d_text[]=', $d_text);
+  unset($_POST['d_text']); // dont repeat the $_POST variable
 }
 
 // Main loop


### PR DESCRIPTION
fixes #8 

@vinceq-usgs this only requires changing one application. Another solution would be to just use the same `d_text` query string parameter with some sort of separator that you parse on the backend.

I made four random damage selections, and this is the output:
`&d_text[]=_crackwallfew&d_text[]=_tilesfell&d_text[]=_crackchim&d_text[]=_move`