### PR TITLE
Issue 29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ COPY src/lib/ /var/www/lib/
 
 
 EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=15s --start-period=30s --retries=1 CMD [ "/var/www/lib/healthcheck.sh" ]

--- a/src/lib/healthcheck.sh
+++ b/src/lib/healthcheck.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+## Health check script for docker container
+# Check for recent responses.
+# If no recent responses are found, send one and check again.
+
+
+BACKUP_DIR=${BACKUP_DIR:-'/backup'}
+RESPONSES_DIR="${BACKUP_DIR}/responses"
+if [ ! -d $RESPONSES_DIR ]; then
+  mkdir -p $RESPONSES_DIR
+  chmod 777 $RESPONSES_DIR
+fi
+
+
+# check for responses within the past 5 minutes
+num_responses=$(find $RESPONSES_DIR -mmin -5 -name '*' -type f | wc -l)
+echo "Found ${num_responses} responses in past 5 minutes"
+if [ "$num_responses" != "0" ]; then
+  exit 0
+fi
+
+
+# no response found, send one
+echo "Submitting response"
+status=$(
+    curl \
+        --request POST \
+        --data "eventid=healthcheck&fldSituation_felt=0&format=json" \
+        --max-time 5 \
+        --output /dev/null \
+        --silent \
+        --write-out "%{http_code}" \
+        http://localhost/response.php
+)
+if [ "$status" != "200" ]; then
+  echo "Error submitting response, expected 200 got ${status}"
+  exit 1
+fi
+
+# expect the response we just sent to be found
+num_responses=$(find $RESPONSES_DIR -mmin -5 -name '*' -type f | wc -l)
+if [ "$num_responses" != "0" ]; then
+  echo "Response submitted successfully"
+  exit 0
+fi
+echo "Response was not output as expected"
+exit 1

--- a/src/lib/healthcheck.sh
+++ b/src/lib/healthcheck.sh
@@ -16,7 +16,7 @@ fi
 # check for responses within the past 5 minutes
 num_responses=$(find $RESPONSES_DIR -mmin -5 -name '*' -type f | wc -l)
 echo "Found ${num_responses} responses in past 5 minutes"
-if [ "$num_responses" != "0" ]; then
+if [ "${num_responses}" != "0" ]; then
   exit 0
 fi
 
@@ -30,17 +30,18 @@ status=$(
         --max-time 5 \
         --output /dev/null \
         --silent \
+        --user-agent "Docker Healthcheck" \
         --write-out "%{http_code}" \
         http://localhost/response.php
 )
-if [ "$status" != "200" ]; then
+if [ "${status}" != "200" ]; then
   echo "Error submitting response, expected 200 got ${status}"
   exit 1
 fi
 
 # expect the response we just sent to be found
 num_responses=$(find $RESPONSES_DIR -mmin -5 -name '*' -type f | wc -l)
-if [ "$num_responses" != "0" ]; then
+if [ "${num_responses}" != "0" ]; then
   echo "Response submitted successfully"
   exit 0
 fi

--- a/src/lib/healthcheck.sh
+++ b/src/lib/healthcheck.sh
@@ -1,21 +1,24 @@
 #! /bin/bash
 
 ## Health check script for docker container
-# Check for recent responses.
+# Check for recent responses (within RESPONSE_MAX_AGE_MINUTES minutes).
 # If no recent responses are found, send one and check again.
 
 
 BACKUP_DIR=${BACKUP_DIR:-'/backup'}
 RESPONSES_DIR="${BACKUP_DIR}/responses"
+RESPONSE_MAX_AGE_MINUTES=1
+
+
 if [ ! -d $RESPONSES_DIR ]; then
   mkdir -p $RESPONSES_DIR
   chmod 777 $RESPONSES_DIR
 fi
 
 
-# check for responses within the past 5 minutes
-num_responses=$(find $RESPONSES_DIR -mmin -5 -name '*' -type f | wc -l)
-echo "Found ${num_responses} responses in past 5 minutes"
+# check for responses within the past minute
+num_responses=$(find $RESPONSES_DIR -mmin -${RESPONSE_MAX_AGE_MINUTES} -name '*' -type f | wc -l)
+echo "Found ${num_responses} responses in past ${RESPONSE_MAX_AGE_MINUTES} minutes"
 if [ "${num_responses}" != "0" ]; then
   exit 0
 fi
@@ -40,7 +43,7 @@ if [ "${status}" != "200" ]; then
 fi
 
 # expect the response we just sent to be found
-num_responses=$(find $RESPONSES_DIR -mmin -5 -name '*' -type f | wc -l)
+num_responses=$(find $RESPONSES_DIR -mmin -${RESPONSE_MAX_AGE_MINUTES} -name '*' -type f | wc -l)
 if [ "${num_responses}" != "0" ]; then
   echo "Response submitted successfully"
   exit 0


### PR DESCRIPTION
Fixes #29 

Used 30 second interval, since it takes 1 interval until the container can be considered healthy.  The health check script posts a response no more than once every 5 minutes, if no other responses are received, and isn't expected to add significant load.